### PR TITLE
Update plugin.json

### DIFF
--- a/rabbitmq/plugin.json
+++ b/rabbitmq/plugin.json
@@ -8,7 +8,8 @@
         "RABBITMQ_ENABLED_PLUGINS_FILE": "{{.DevboxDir}}/conf.d/enabled_plugins",
         "RABBITMQ_LOG_BASE": "{{.Virtenv}}/log",
         "RABBITMQ_NODENAME": "rabbit",
-        "RABBITMQ_PID_FILE": "{{.Virtenv}}/pid/$RABBITMQ_NODENAME.pid"
+        "RABBITMQ_PID_FILE": "{{.Virtenv}}/pid/$RABBITMQ_NODENAME.pid",
+        "ELIXIR_ERL_OPTIONS": "+fnu"
     },
     "create_files": {
         "{{.DevboxDir}}/conf.d/rabbitmq.conf": "config/rabbitmq.conf",


### PR DESCRIPTION
Add `$ELIXIR_ERL_OPTIONS` env variable  and set to `+fnu` to avoid this warning:

```
warning: the VM is running with native name encoding of latin1 which may cause Elixir to malfunction as it expects utf8. Please ensure your locale is set to UTF-8 (which can be verified by running "locale" in your shell) or set the ELIXIR_ERL_OPTIONS="+fnu" environment variable
```

In my case, this was when I activated the `rabbitmq_management` plugin.